### PR TITLE
fix: Given don’t turn on Alt and directly option, click word-card will just appear button instead of dialog in option page

### DIFF
--- a/src/components/vue/selection-mixin.js
+++ b/src/components/vue/selection-mixin.js
@@ -95,7 +95,11 @@ export default {
       // 如果设置了直接翻译则直接显示结果面板
       const isDirectly = await $storage.get(TR_SETTING_IS_DIRECTLY_KEY)
       const keyboardCtrl = await $storage.get(TR_SETTING_KEYBOARD_CONTROL)
-      this.panelVisible = isDirectly || keyboardCtrl
+      if (inExtension) {
+        this.panelVisible = true
+      } else {
+        this.panelVisible = isDirectly || keyboardCtrl
+      }
       this.translationResult = null
       this.translateLoaded = false
 


### PR DESCRIPTION
Entry:

option page  
#link=vocabulary

Given：

Don’t turn on Alt and directly option

![image](https://user-images.githubusercontent.com/24861316/45593825-26779d00-b9c1-11e8-9b5b-6455d503b9b8.png)

 Not fixed yet：

![image](https://user-images.githubusercontent.com/24861316/45593828-2d061480-b9c1-11e8-88be-8cb48906b453.png)

Fixed 

![image](https://user-images.githubusercontent.com/24861316/45593861-b289c480-b9c1-11e8-8a5c-413d8a8725e5.png)




请review  哈哈哈哈   