### PR TITLE
feat: remove the influence of 'ALT control' on  option page

### DIFF
--- a/src/components/vue/selection-mixin.js
+++ b/src/components/vue/selection-mixin.js
@@ -37,10 +37,6 @@ export default {
 
       let condition = translateLoaded && panelVisible && selection
 
-      if (hasAltControl) {
-        condition = condition && hasAltPressed
-      }
-
       return condition
     }
   },

--- a/src/components/vue/selection-mixin.js
+++ b/src/components/vue/selection-mixin.js
@@ -36,6 +36,10 @@ export default {
       const { panelVisible, selection, translateLoaded, hasAltControl, hasAltPressed } = this
 
       let condition = translateLoaded && panelVisible && selection
+      
+      if (hasAltControl) {
+        condition = condition && hasAltPressed
+      }
 
       return condition
     }
@@ -63,7 +67,7 @@ export default {
   },
 
   async mounted() {
-    this.hasAltControl = await this.$storage.get(TR_SETTING_KEYBOARD_CONTROL, false)
+    this.hasAltControl = (await this.$storage.get(TR_SETTING_KEYBOARD_CONTROL, false)) && !this.$root.inExtension
 
     if (this.hasAltControl) {
       document.addEventListener('keydown', this.onAltKeyDown)


### PR DESCRIPTION
这个是我的个人愚见啦

当我开了 alt control 功能

![image](https://user-images.githubusercontent.com/24861316/45593940-22994a00-b9c4-11e8-9c87-bc5eee0da8b3.png)

这个word-card就没办法直接打开啦，只能再摁一次alt 键(有点多此一举) ，而且此时不摁alt键这个页面就都没办法操作了，因为被蒙层盖住啦。

![image](https://user-images.githubusercontent.com/24861316/45593980-13ff6280-b9c5-11e8-987d-39db94f980ba.png)


最后赞一下，alt 键控制划词翻译很贴心~~感谢

