### PR TITLE
修复sogou升级修改API token，导致翻译失败的bug

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,12 +2,13 @@ import { google, sougou, shanbay, cdn, youdao } from './client'
 import { _sougouUuid } from '@/utils'
 import md5 from 'md5'
 
+let token = 'b33bf8c58706155663d1ad5dba4192dc'
 export default {
   sougouTranslate(text) {
     const from = 'auto'
     const to = 'zh-CHS'
-    // 搜狗 API 新增加的一个字段，后面固定的 `front_xxxxx` 目前意义不明，先写死
-    const s = md5('' + from + to + text + '41ee21a5ab5a13f72687a270816d1bfd')
+    // 搜狗 API 新增加的一个字段，后面固定的 `front_xxxxx` 目前意义不明
+    const s = md5('' + from + to + text + token)
     text = encodeURIComponent(text).replace(/%20/g, '+')
 
     const payload = {
@@ -30,7 +31,19 @@ export default {
       .map(([k, v]) => k + '=' + v)
       .join('&')
 
-    return sougou.post('/reventondc/translate', data)
+    return sougou.post('/reventondc/translate', data).then(async res => {
+      if (res.errorCode === 0) return res
+      // 如果翻译失败,尝试从js源码中获取token
+      let s = await sougou.get('/')
+      let m = /js\/app\.([^.]+)/.exec(s)
+      if (!m) throw res
+      s = await sougou.get('https://dlweb.sogoucdn.com/translate/pc/static/js/app.' + m[1] + '.js')
+      m = /""\+\w\+\w\+\w\+"(\w{32})"/.exec(s)
+      if (!m) throw res
+      if (token === m[1]) throw res
+      token = m[1]
+      return this.sougouTranslate(text)
+    })
   },
 
   // ------------------------------ 扇 贝 ---------------------------------------------


### PR DESCRIPTION
// 搜狗 API 新增加的一个字段，后面固定的 `front_xxxxx` 目前意义不明
由于这个字段在sogou升级后变化，所以尝试从源码中获取这个字段