### PR TITLE
Update module dependence md5 and other

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "dadda-translate",
+  "private": true,
   "version": "1.2.0",
   "description": "translate and remember",
   "scripts": {
-    "dev": "node_modules/.bin/webpack --progress --config build/webpack.dev.js",
-    "build": "rm -rf ./dist && node_modules/.bin/webpack --config build/webpack.production.js"
+    "dev": "webpack --progress --config build/webpack.dev.js",
+    "build": "rm -rf ./dist && webpack --config build/webpack.production.js"
   },
   "keywords": [
     "translate",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "url": "https://github.com/waynecz/dadda-translate-crx/issues"
   },
   "dependencies": {
+    "@xn-02f/md5": "^2.0.0",
     "axios": "^0.18.0",
     "lodash-es": "^4.17.7",
-    "md5": "^2.2.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.7",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,6 @@
 import { google, sougou, shanbay, cdn, youdao } from './client'
 import { _sougouUuid } from '@/utils'
-import md5 from 'md5'
+import md5 from '@xn-02f/md5'
 
 let token = 'b33bf8c58706155663d1ad5dba4192dc'
 export default {


### PR DESCRIPTION
1. Update package.json file:
- Add `private` property (set it `true`).
- Remove 'node_modules/.bin/' in `script` property: it is default env when you use run npm script.

2. Change **md5** dependence from [`md5`](https://www.npmjs.com/package/md5) to [`@xn-02f/md5`](https://www.npmjs.com/package/@xn-02f/md5):
- `@xn-02f/md5` is library with zero dependence, `md5` depend on `charenc`, `crypt` and `is-buffer`.
- `@xn-02f/md5` is more suitable and more secure than `md5` for your usage.