### PR TITLE
remove seccode require

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -39,7 +39,7 @@ async function getSeccode() {
 
 export default {
   sougouTranslate(text) {
-    getSeccode()
+    // getSeccode()
     const from = 'auto'
     const to = 'zh-CHS'
 


### PR DESCRIPTION
seccode看起来还是会命中搜狗反作弊，一命中就导致无法进入下面的翻译流程
而且不获取seccode并看上去不影响搜狗的翻译。